### PR TITLE
(#11767) Fix chown on Windows

### DIFF
--- a/templates/scripts/manage_root_authorized_keys
+++ b/templates/scripts/manage_root_authorized_keys
@@ -6,6 +6,13 @@ set -u
 # MAKE SURE THIS IS SSL!
 URL="https://raw.github.com/puppetlabs/puppetlabs-sshkeys/master/templates/ssh/authorized_keys"
 
+if [[ `uname` == CYGWIN* ]]
+then
+  OWNER="root:none"
+else
+  OWNER="0:0"
+fi
+
 if which wget >/dev/null
 then
   GET="wget -q -O - ${URL}"
@@ -17,7 +24,7 @@ if ! [[ -d ~root/.ssh/ ]]
 then
   mkdir ~root/.ssh/
   chmod 700 ~root/.ssh/
-  chown 0:0 ~root/.ssh/
+  chown $OWNER ~root/.ssh/
 fi
 
 # Make sure there is no temporary file
@@ -31,7 +38,7 @@ if ! [[ -f ~root/.ssh/authorized_keys.tmp ]]
 then
   touch ~root/.ssh/authorized_keys.tmp
   chmod 644 ~root/.ssh/authorized_keys.tmp
-  chown 0:0 ~root/.ssh/authorized_keys.tmp
+  chown $OWNER ~root/.ssh/authorized_keys.tmp
 fi
 
 # Download the file.  If this fails the script will abort since we're set -e


### PR DESCRIPTION
Previously, on cygwin/windows, the command:

  chown 0:0 ~root/.ssh/authorized_keys.tmp

would fail because 0 is not a valid user or group identifier on Windows.

This commit uses the `uname` command to detect when running under Cygwin
and does a `chown root:none` instead, which is consistent with how
Cygwin manages other root-owned files.
