### PR TITLE
[maint] Use short opt to `mv`

### DIFF
--- a/templates/scripts/manage_root_authorized_keys
+++ b/templates/scripts/manage_root_authorized_keys
@@ -49,4 +49,4 @@ fi
 $GET > $SSH_HOME/authorized_keys.tmp
 
 # Now move the file into place.  POSIX rename is atomic.
-mv --force $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys
+mv -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys


### PR DESCRIPTION
This allows the script to run on our FOSS testing versions of solaris
