### PR TITLE
Switch to curl as the preferred http client

### DIFF
--- a/templates/scripts/manage_root_authorized_keys
+++ b/templates/scripts/manage_root_authorized_keys
@@ -17,11 +17,11 @@ else
   SSH_HOME=~root/.ssh/
 fi
 
-if which wget >/dev/null
+if which curl 2>&1 >/dev/null
 then
-  GET="wget -q -O - ${URL}"
-else
   GET="curl -o - ${URL}"
+else
+  GET="wget -q -O - ${URL}"
 fi
 
 if ! [[ -d $SSH_HOME ]]


### PR DESCRIPTION
Without this patch wget is the preferred client.  This is a problem
because wget on a CentOS 6 host returns the following error talking to
Github:

```
$ wget https://raw.github.com/puppetlabs/puppetlabs-sshkeys/master/templates/scripts/manage_root_authorized_keys
ERROR: certificate common name “*.a.ssl.fastly.net” doesn’t match requested host name “raw.github.com”.
```

Curl does not have this issue and is often installed along side wget.
This patch prefers curl in an effort to reduce the likelihood of the
issue.
