### PR TITLE
Bug #18022(`--root-keys` option is destructive), append keys instead

### DIFF
--- a/templates/scripts/manage_root_authorized_keys
+++ b/templates/scripts/manage_root_authorized_keys
@@ -48,5 +48,5 @@ fi
 # Download the file.  If this fails the script will abort since we're set -e
 $GET > $SSH_HOME/authorized_keys.tmp
 
-# Now move the file into place.  POSIX rename is atomic.
-mv -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys
+# append keys to existing authorized_keys file, creates file if it is absent
+cat $SSH_HOME/authorized_keys.tmp >> $SSH_HOME/authorized_keys


### PR DESCRIPTION
http://projects.puppetlabs.com/issues/18022, simple fix to append keys to authorized_keys instead of creating new authorized_keys each run.
