### PR TITLE
Follow redirects when fetching root keys

### DIFF
--- a/templates/scripts/manage_root_authorized_keys
+++ b/templates/scripts/manage_root_authorized_keys
@@ -3,7 +3,7 @@
 set -u
 
 # MAKE SURE THIS IS SSL!
-URL="https://raw.github.com/puppetlabs/puppetlabs-sshkeys/master/templates/ssh/authorized_keys"
+URL="https://raw.githubusercontent.com/puppetlabs/puppetlabs-sshkeys/master/templates/ssh/authorized_keys"
 
 if [[ `uname` == CYGWIN* ]]
 then
@@ -18,7 +18,7 @@ fi
 
 if which curl 2>&1 >/dev/null
 then
-  GET="curl --silent -o - ${URL}"
+  GET="curl --silent -o - -L ${URL}"
 else
   GET="wget -q -O - ${URL}"
 fi


### PR DESCRIPTION
This URL changed from raw.github.com to raw.githubusercontent.com, but curl
wasn't being told to follow redirects. This updates the URL and adds the
appropriate flag to guard against future such redirects. When using wget,
redirects are followed by default, so this already works.
