### PR TITLE
EOS root-key setup fix

### DIFF
--- a/templates/scripts/manage_root_authorized_keys
+++ b/templates/scripts/manage_root_authorized_keys
@@ -61,5 +61,6 @@ then
   cat $SSH_HOME/authorized_keys.{local,downloaded} | sort | uniq > $SSH_HOME/authorized_keys.tmp
 fi
 
-# Now move the file into place.  POSIX rename is atomic.
-mv -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys
+# Now move the file into place.
+cp -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys
+rm -f $SSH_HOME/authorized_keys.tmp


### PR DESCRIPTION
On EOS, executing a move command here fails to setup
authorized_keys correctly.  Changing from a 'mv -f'
to a 'cp -f' fixes this, however, while not changing
the functionality required
